### PR TITLE
Refactor build scripts and PyInstaller spec for architecture support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,25 +36,29 @@ jobs:
   build:
     needs: test
     name: Build ${{ matrix.os }}-${{ matrix.arch }}
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false # Don't cancel other jobs if one fails
       matrix:
         include:
           - os: ubuntu-latest
             arch: x64
+            runner: ubuntu-latest
             artifact_name: ArchImmich-linux-x64
             build_script: ./scripts/build-linux.sh
           - os: ubuntu-latest
             arch: arm64
+            runner: ubuntu-arm64
             artifact_name: ArchImmich-linux-arm64
             build_script: ./scripts/build-linux.sh
           - os: windows-latest
             arch: x64
+            runner: windows-latest
             artifact_name: ArchImmich-windows
             build_script: scripts\build-windows.bat
           - os: macos-latest
             arch: arm64
+            runner: macos-latest
             artifact_name: ArchImmich-macos
             build_script: ./scripts/build-macos.sh
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,20 +35,26 @@ jobs:
 
   build:
     needs: test
-    name: Build ${{ matrix.os }}
+    name: Build ${{ matrix.os }}-${{ matrix.arch }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false # Don't cancel other jobs if one fails
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
         include:
           - os: ubuntu-latest
-            artifact_name: ArchImmich-linux
+            arch: x64
+            artifact_name: ArchImmich-linux-x64
+            build_script: ./scripts/build-linux.sh
+          - os: ubuntu-latest
+            arch: arm64
+            artifact_name: ArchImmich-linux-arm64
             build_script: ./scripts/build-linux.sh
           - os: windows-latest
+            arch: x64
             artifact_name: ArchImmich-windows
             build_script: scripts\build-windows.bat
           - os: macos-latest
+            arch: x64
             artifact_name: ArchImmich-macos
             build_script: ./scripts/build-macos.sh
 
@@ -101,6 +107,7 @@ jobs:
         shell: bash
         env:
           GITHUB_WORKSPACE: ${{ github.workspace }}
+          TARGET_ARCH: ${{ matrix.arch }}
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
             artifact_name: ArchImmich-windows
             build_script: scripts\build-windows.bat
           - os: macos-latest
-            arch: x64
+            arch: arm64
             artifact_name: ArchImmich-macos
             build_script: ./scripts/build-macos.sh
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,7 @@ jobs:
             build_script: ./scripts/build-linux.sh
           - os: ubuntu-latest
             arch: arm64
-            runner: ubuntu-arm64
+            runner: ubuntu-22.04-arm
             artifact_name: ArchImmich-linux-arm64
             build_script: ./scripts/build-linux.sh
           - os: windows-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,11 +46,11 @@ jobs:
             runner: ubuntu-latest
             artifact_name: ArchImmich-linux-x64
             build_script: ./scripts/build-linux.sh
-          - os: ubuntu-latest
-            arch: arm64
-            runner: ubuntu-22.04-arm
-            artifact_name: ArchImmich-linux-arm64
-            build_script: ./scripts/build-linux.sh
+          # - os: ubuntu-latest
+          #   arch: arm64
+          #   runner: ubuntu-22.04-arm
+          #   artifact_name: ArchImmich-linux-arm64
+          #   build_script: ./scripts/build-linux.sh
           - os: windows-latest
             arch: x64
             runner: windows-latest

--- a/archimmich.spec
+++ b/archimmich.spec
@@ -1,8 +1,12 @@
 # -*- mode: python ; coding: utf-8 -*-
 from PyInstaller.utils.hooks import collect_dynamic_libs
 from PyInstaller.utils.hooks import collect_all
+import os
 
-datas = [('src/resources', 'src/resources')]
+# Get target architecture from environment or default to x86_64
+TARGET_ARCH = os.environ.get('TARGET_ARCH', 'x86_64')
+
+datas = [('src/resources/*', 'src/resources')]
 binaries = []
 hiddenimports = []
 binaries += collect_dynamic_libs('_internal')
@@ -40,7 +44,7 @@ exe = EXE(
     console=False,
     disable_windowed_traceback=False,
     argv_emulation=False,
-    target_arch=None,
+    target_arch=TARGET_ARCH,
     codesign_identity=None,
     entitlements_file=None,
     icon=['src\\resources\\favicon-180.png'],

--- a/scripts/build-windows.bat
+++ b/scripts/build-windows.bat
@@ -4,6 +4,13 @@ echo Running build-windows.bat script...
 :: Get version from version.txt
 set /p VERSION=<version.txt
 
+:: Get architecture from environment or default to x64
+if defined TARGET_ARCH (
+    set ARCH=%TARGET_ARCH%
+) else (
+    set ARCH=x64
+)
+
 :: Run PyInstaller
 pyinstaller ^
   --onedir ^
@@ -24,7 +31,7 @@ if not exist "release" mkdir release
 
 :: Create zip file
 cd dist\ArchImmich
-powershell Compress-Archive -Path * -DestinationPath ..\..\release\ArchImmich_Windows_v%VERSION%.zip -Force
+powershell Compress-Archive -Path * -DestinationPath ..\..\release\ArchImmich_Windows_%ARCH%_v%VERSION%.zip -Force
 cd ..\..
 
 echo Windows build completed successfully!

--- a/scripts/create-tar.gz.sh
+++ b/scripts/create-tar.gz.sh
@@ -21,8 +21,20 @@ if [ ! -d "dist/ArchImmich" ]; then
     exit 1
 fi
 
-# Set the output filename
-TARBALL="release/ArchImmich_Linux_v${VERSION}.tar.gz"
+# Get architecture from environment or detect it
+if [ -n "$TARGET_ARCH" ]; then
+    ARCH="$TARGET_ARCH"
+else
+    ARCH=$(uname -m)
+    if [ "$ARCH" = "aarch64" ] || [ "$ARCH" = "arm64" ]; then
+        ARCH="arm64"
+    else
+        ARCH="x64"
+    fi
+fi
+
+# Set the output filename with architecture
+TARBALL="release/ArchImmich_Linux_${ARCH}_v${VERSION}.tar.gz"
 
 # Remove existing tarball if it exists
 if [ -f "$TARBALL" ]; then
@@ -31,7 +43,7 @@ if [ -f "$TARBALL" ]; then
 fi
 
 # Create a tarball with the version included in the filename
-echo "Creating Linux tarball..."
+echo "Creating Linux ${ARCH} tarball..."
 tar -czf "$TARBALL" -C dist ArchImmich
 
 # Verify the tarball was created

--- a/scripts/create-tar.gz.sh
+++ b/scripts/create-tar.gz.sh
@@ -49,6 +49,16 @@ tar -czf "$TARBALL" -C dist ArchImmich
 # Verify the tarball was created
 if [ -f "$TARBALL" ]; then
     echo "Successfully created: $TARBALL"
+
+    # Log checksum and architecture info
+    echo "=== Build Verification ==="
+    echo "Target architecture: $ARCH"
+    echo "System architecture: $(uname -m)"
+    echo "Binary architecture: $(file dist/ArchImmich/ArchImmich | grep -o 'ARM aarch64\|x86-64\|Intel 80386' || echo 'unknown')"
+    echo "Binary checksum: $(shasum -a 256 dist/ArchImmich/ArchImmich | cut -d' ' -f1)"
+    echo "Tarball checksum: $(shasum -a 256 "$TARBALL" | cut -d' ' -f1)"
+    echo "Tarball size: $(ls -lh "$TARBALL" | awk '{print $5}')"
+    echo "=========================="
 else
     echo "Error: Failed to create tarball"
     exit 1

--- a/scripts/pyinstaller.sh
+++ b/scripts/pyinstaller.sh
@@ -1,5 +1,22 @@
 #!/bin/sh
 
+# Detect target architecture from environment or system
+if [ -n "$TARGET_ARCH" ]; then
+    echo "Using target architecture: $TARGET_ARCH"
+elif [ "$(uname -m)" = "x86_64" ]; then
+    TARGET_ARCH="x86_64"
+    echo "Detected x86_64 architecture"
+elif [ "$(uname -m)" = "aarch64" ] || [ "$(uname -m)" = "arm64" ]; then
+    TARGET_ARCH="aarch64"
+    echo "Detected ARM64 architecture"
+else
+    TARGET_ARCH="x86_64"  # Default to x86_64 for compatibility
+    echo "Defaulting to x86_64 architecture"
+fi
+
+# Export TARGET_ARCH for PyInstaller to use
+export TARGET_ARCH
+
 # Add platform-specific options
 case "$(uname)" in
   "Darwin")
@@ -30,6 +47,10 @@ fi
 
 # Clean previous builds
 rm -rf build dist
+
+echo "Building for architecture: $TARGET_ARCH"
+echo "PyInstaller command: $PYINSTALLER"
+echo "Platform options: $PLATFORM_OPTS"
 
 $PYINSTALLER \
   --onedir \


### PR DESCRIPTION
- Introduced TARGET_ARCH environment variable to dynamically set target architecture for builds.
- Updated PyInstaller spec to use TARGET_ARCH for architecture-specific builds.
- Enhanced GitHub Actions workflow to include architecture in job names and artifact names, supporting both x64 and arm64 builds.
- Modified build scripts to detect and export target architecture for improved compatibility across platforms.